### PR TITLE
Added use_tracer_interceptor config parameter

### DIFF
--- a/DependencyInjection/AmqpConfiguration.php
+++ b/DependencyInjection/AmqpConfiguration.php
@@ -47,6 +47,7 @@ class AmqpConfiguration implements TransportSectionConfiguration
             ->addDefaultsIfNotSet()
             ->children()
                 ->enumNode('driver')->values(['amqplib', 'pecl'])->defaultValue('amqplib')->end()
+                ->booleanNode('use_tracer_interceptor')->defaultFalse()->cannotBeEmpty()->end()
                 ->arrayNode('connections')->info('Connection with name "default" is added')
                     ->useAttributeAsKey('name')
                     ->addDefaultChildrenIfNoneSet('default')

--- a/DependencyInjection/EventBandExtension.php
+++ b/DependencyInjection/EventBandExtension.php
@@ -54,7 +54,7 @@ class EventBandExtension extends ConfigurableExtension
         $this->loader->load('transport/amqp/amqp.xml');
         $this->loader->load(sprintf('transport/amqp/%s.xml', $config['driver']));
 
-        if (class_exists('JMS\AopBundle\JMSAopBundle')) {
+        if ($config['use_tracer_interceptor'] === true && class_exists('JMS\AopBundle\JMSAopBundle')) {
             $this->loader->load('transport/amqp/tracer.xml');
         }
 

--- a/Tests/DependencyInjection/AmqpConfigurationTest.php
+++ b/Tests/DependencyInjection/AmqpConfigurationTest.php
@@ -33,6 +33,7 @@ class AmqpConfigurationTest extends SectionConfigurationTestCase
         $this->assertEquals(
             [
                 'driver' => 'amqplib',
+                'use_tracer_interceptor' => false,
                 'connections' => [
                     'default' => AmqpConfiguration::getDefaultConnection()
                 ],


### PR DESCRIPTION
The problem: we use aopBundle, but we don't need tracer interceptor in event band, because of memory leak.
Solution: use config parameter instead of class_exists().
